### PR TITLE
feat: warn on duplicate env keys

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,6 +39,10 @@ dotenv-diff --check-values
 
 When using the `--check-values` option, the tool will also compare the actual values of the variables in `.env` and `.env.example`. It will report any mismatches found and it also compares values if .env.example defines a non-empty expected value.
 
+## Duplicate key warnings
+
+`dotenv-diff` warns when a `.env*` file contains the same key multiple times. The last occurrence wins. Suppress these warnings with `--allow-duplicates`.
+
 ## Compare specific files
 
 Override the autoscan and compare exactly two files:

--- a/channellog.md
+++ b/channellog.md
@@ -1,0 +1,12 @@
+## [Unreleased]
+
+### Added
+- Duplicate key detection for `.env*` files.
+  - Prints warnings listing duplicate keys (last occurrence wins).
+  - Suppress via `--allow-duplicates`.
+
+### Changed
+- No breaking changes. Exit codes and diff behavior unchanged.
+
+### Fixed
+- N/A

--- a/channellog.md
+++ b/channellog.md
@@ -1,4 +1,6 @@
-## [Unreleased]
+# Changelog
+
+## 1.6.2
 
 ### Added
 - Duplicate key detection for `.env*` files.
@@ -8,5 +10,22 @@
 ### Changed
 - No breaking changes. Exit codes and diff behavior unchanged.
 
-### Fixed
-- N/A
+## 1.6.1
+
+### Added
+- `--env` and `--example` for direct file comparison; autoscan overridden when both are provided.
+- `--ci` and `--yes` non-interactive modes.
+
+### Changed
+- Updated TypeScript configuration to include `bin` directory.
+- Changed CLI path to `bin/dotenv-diff.js` for consistency.
+- Refactored folder structure for better organization.
+## 1.6.0
+
+### Added
+- `--env` and `--example` for direct file comparison; autoscan overridden when both are provided.
+
+## 1.5.0
+
+### Added
+- `--ci` and `--yes` non-interactive modes.

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "dotenv-diff",
-  "version": "2.0.0",
+  "version": "1.6.2",
   "type": "module",
   "description": "A small CLI and library to find differences between .env and .env.example files.",
   "bin": {

--- a/src/cli/program.ts
+++ b/src/cli/program.ts
@@ -8,5 +8,9 @@ export function createProgram() {
     .option('--ci', 'Run non-interactively and never create files')
     .option('-y, --yes', 'Run non-interactively and answer Yes to prompts')
     .option('--env <file>', 'Path to a specific .env file')
-    .option('--example <file>', 'Path to a specific .env.example file');
+    .option('--example <file>', 'Path to a specific .env.example file')
+    .option(
+      '--allow-duplicates',
+      'Do not warn about duplicate keys in .env* files',
+    );
 }

--- a/src/cli/run.ts
+++ b/src/cli/run.ts
@@ -42,7 +42,11 @@ export async function run(program: Command) {
           examplePath: opts.exampleFlag,
         },
       ],
-      { checkValues: opts.checkValues, cwd: opts.cwd },
+      {
+        checkValues: opts.checkValues,
+        cwd: opts.cwd,
+        allowDuplicates: opts.allowDuplicates,
+      },
     );
     process.exit(exitWithError ? 1 : 0);
   }
@@ -68,6 +72,7 @@ export async function run(program: Command) {
   const { exitWithError } = await compareMany(pairs, {
     checkValues: opts.checkValues,
     cwd: opts.cwd,
+    allowDuplicates: opts.allowDuplicates,
   });
   process.exit(exitWithError ? 1 : 0);
 }

--- a/src/commands/compare.ts
+++ b/src/commands/compare.ts
@@ -4,7 +4,7 @@ import chalk from 'chalk';
 import { parseEnvFile } from '../lib/parseEnv.js';
 import { diffEnv } from '../lib/diffEnv.js';
 import { warnIfEnvNotIgnored } from '../services/git.js';
-import { findDuplicateKeys } from '../core/duplicates.js';
+import { findDuplicateKeys } from '../services/duplicates.js';
 
 export async function compareMany(
   pairs: Array<{ envName: string; envPath: string; examplePath: string }>,
@@ -45,9 +45,7 @@ export async function compareMany(
           ),
         );
         dupsEnv.forEach(({ key, count }) =>
-          console.log(
-            chalk.yellow(`      - ${key} (${count} occurrences)`),
-          ),
+          console.log(chalk.yellow(`      - ${key} (${count} occurrences)`)),
         );
       }
 
@@ -60,9 +58,7 @@ export async function compareMany(
           ),
         );
         dupsEx.forEach(({ key, count }) =>
-          console.log(
-            chalk.yellow(`      - ${key} (${count} occurrences)`),
-          ),
+          console.log(chalk.yellow(`      - ${key} (${count} occurrences)`)),
         );
       }
     }

--- a/src/config/options.ts
+++ b/src/config/options.ts
@@ -5,6 +5,7 @@ export type Options = {
   checkValues: boolean;
   isCiMode: boolean;
   isYesMode: boolean;
+  allowDuplicates: boolean;
   envFlag: string | null;
   exampleFlag: string | null;
   cwd: string;
@@ -14,6 +15,7 @@ type RawOptions = {
   checkValues?: boolean;
   ci?: boolean;
   yes?: boolean;
+  allowDuplicates?: boolean;
   env?: string;
   example?: string;
 };
@@ -22,6 +24,7 @@ export function normalizeOptions(raw: RawOptions): Options {
   const checkValues = raw.checkValues ?? false;
   const isCiMode = Boolean(raw.ci);
   const isYesMode = Boolean(raw.yes);
+  const allowDuplicates = Boolean(raw.allowDuplicates);
 
   if (isCiMode && isYesMode) {
     console.log(
@@ -37,5 +40,13 @@ export function normalizeOptions(raw: RawOptions): Options {
   const exampleFlag =
     typeof raw.example === 'string' ? path.resolve(cwd, raw.example) : null;
 
-  return { checkValues, isCiMode, isYesMode, envFlag, exampleFlag, cwd };
+  return {
+    checkValues,
+    isCiMode,
+    isYesMode,
+    allowDuplicates,
+    envFlag,
+    exampleFlag,
+    cwd,
+  };
 }

--- a/src/core/duplicates.ts
+++ b/src/core/duplicates.ts
@@ -1,0 +1,36 @@
+import fs from 'fs';
+
+/**
+ * Scan a .env-like file for duplicate keys.
+ * - Ignores empty lines and comments (#...)
+ * - Splits on first '='
+ * - Trims the key
+ * - Returns keys that appear more than once, with counts
+ */
+export function findDuplicateKeys(filePath: string): Array<{ key: string; count: number }> {
+  if (!fs.existsSync(filePath)) return [];
+
+  const raw = fs.readFileSync(filePath, 'utf8');
+  const lines = raw.split('\n');
+
+  const counts = new Map<string, number>();
+
+  for (const line of lines) {
+    const trimmed = line.trim();
+    if (!trimmed || trimmed.startsWith('#')) continue;
+
+    const eq = trimmed.indexOf('=');
+    if (eq <= 0) continue; // no '=' or empty key
+
+    const key = trimmed.slice(0, eq).trim();
+    if (!key) continue;
+
+    counts.set(key, (counts.get(key) ?? 0) + 1);
+  }
+
+  const duplicates: Array<{ key: string; count: number }> = [];
+  for (const [key, count] of counts) {
+    if (count > 1) duplicates.push({ key, count });
+  }
+  return duplicates;
+}

--- a/src/services/duplicates.ts
+++ b/src/services/duplicates.ts
@@ -7,7 +7,9 @@ import fs from 'fs';
  * - Trims the key
  * - Returns keys that appear more than once, with counts
  */
-export function findDuplicateKeys(filePath: string): Array<{ key: string; count: number }> {
+export function findDuplicateKeys(
+  filePath: string,
+): Array<{ key: string; count: number }> {
   if (!fs.existsSync(filePath)) return [];
 
   const raw = fs.readFileSync(filePath, 'utf8');


### PR DESCRIPTION
## Summary
- warn about duplicate keys in `.env*` files
- allow suppressing duplicate warnings with `--allow-duplicates`
- document duplicate detection

## Testing
- `pnpm test --run`


------
https://chatgpt.com/codex/tasks/task_e_6899923959948333940dddcb46f0091d