### PR TITLE
test: reorganize and expand test suite

### DIFF
--- a/package.json
+++ b/package.json
@@ -24,7 +24,9 @@
   "scripts": {
     "build": "tsc",
     "dev": "vitest --watch",
-    "test": "vitest",
+    "test": "vitest run",
+    "test:unit": "vitest run test/unit",
+    "test:e2e": "vitest run test/e2e",
     "lint": "eslint ./src --ext .ts",
     "format": "prettier --write \"src/**/*.ts\" \"src/*.ts\"",
     "start": "node dist/bin/dotenv-diff.js",

--- a/test/e2e/cli.autoscan.e2e.test.ts
+++ b/test/e2e/cli.autoscan.e2e.test.ts
@@ -1,0 +1,44 @@
+import { describe, it, expect, beforeAll, afterAll, afterEach } from 'vitest';
+import fs from 'fs';
+import path from 'path';
+import { makeTmpDir, rmrf } from '../utils/fs-helpers.js';
+import { buildOnce, runCli, cleanupBuild } from '../utils/cli-helpers.js';
+
+const tmpDirs: string[] = [];
+
+beforeAll(() => {
+  buildOnce();
+});
+
+afterAll(() => {
+  cleanupBuild();
+});
+
+afterEach(() => {
+  while (tmpDirs.length) {
+    const dir = tmpDirs.pop();
+    if (dir) rmrf(dir);
+  }
+});
+
+function tmpDir() {
+  const dir = makeTmpDir();
+  tmpDirs.push(dir);
+  return dir;
+}
+
+describe('no-flag autoscan', () => {
+  it('compares multiple env pairs and reports missing keys', () => {
+    const cwd = tmpDir();
+    fs.writeFileSync(path.join(cwd, '.env'), 'A=1\n');
+    fs.writeFileSync(path.join(cwd, '.env.example'), 'A=1\n');
+    fs.writeFileSync(path.join(cwd, '.env.staging'), 'A=1\n');
+    fs.writeFileSync(path.join(cwd, '.env.example.staging'), 'A=1\nB=1\n');
+
+    const res = runCli(cwd, []);
+    expect(res.status).toBe(1);
+    expect(res.stdout).toContain('Comparing .env ↔ .env.example');
+    expect(res.stdout).toContain('Comparing .env.staging ↔ .env.example.staging');
+    expect(res.stdout).toContain('Missing keys');
+  });
+});

--- a/test/integration/compare-flow.integration.test.ts
+++ b/test/integration/compare-flow.integration.test.ts
@@ -1,0 +1,30 @@
+import { describe, it, expect, afterEach } from 'vitest';
+import path from 'path';
+import { makeTmpDir, touch, rmrf } from '../utils/fs-helpers.js';
+import { parseEnvFile } from '../../src/lib/parseEnv.js';
+import { diffEnv } from '../../src/lib/diffEnv.js';
+
+const tmpDirs: string[] = [];
+
+afterEach(() => {
+  while (tmpDirs.length) {
+    rmrf(tmpDirs.pop()!);
+  }
+});
+
+describe('compare flow', () => {
+  it('parses files and reports differences', () => {
+    const cwd = makeTmpDir();
+    tmpDirs.push(cwd);
+    touch(path.join(cwd, '.env'), 'A=1\nB=2\n');
+    touch(path.join(cwd, '.env.example'), 'A=1\nB=\nC=3\n');
+
+    const current = parseEnvFile(path.join(cwd, '.env'));
+    const example = parseEnvFile(path.join(cwd, '.env.example'));
+    const res = diffEnv(current, example, true);
+
+    expect(res.missing).toEqual(['C']);
+    expect(res.extra).toEqual([]);
+    expect(res.valueMismatches).toEqual([]);
+  });
+});

--- a/test/unit/core.diffEnv.test.ts
+++ b/test/unit/core.diffEnv.test.ts
@@ -1,5 +1,5 @@
-import { describe, expect, it } from "vitest";
-import { diffEnv } from "../src/lib/diffEnv.js";
+import { describe, expect, it } from 'vitest';
+import { diffEnv } from '../../src/lib/diffEnv.js';
 
 describe("diffEnv", () => {
   it("detects missing and extra keys (no value checking)", () => {

--- a/test/unit/services.git.test.ts
+++ b/test/unit/services.git.test.ts
@@ -1,29 +1,16 @@
 import { describe, it, expect, afterEach } from 'vitest';
 import fs from 'fs';
 import path from 'path';
-import os from 'os';
 
 import {
   isGitRepo,
   isEnvIgnoredByGit,
   warnIfEnvNotIgnored,
-} from '../src/services/git.js';
-
-function makeTmpDir() {
-  const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'dotenv-diff-'));
-  return dir;
-}
-function touch(filePath: string, content = '') {
-  fs.mkdirSync(path.dirname(filePath), { recursive: true });
-  fs.writeFileSync(filePath, content);
-}
-function rmrf(p: string) {
-  fs.rmSync(p, { recursive: true, force: true });
-}
+} from '../../src/services/git.js';
+import { makeTmpDir, touch, rmrf } from '../utils/fs-helpers.js';
 
 let tmpDirs: string[] = [];
 afterEach(() => {
-  // clean up temp dirs
   for (const dir of tmpDirs) rmrf(dir);
   tmpDirs = [];
 });

--- a/test/utils/cli-helpers.ts
+++ b/test/utils/cli-helpers.ts
@@ -1,0 +1,28 @@
+import fs from 'fs';
+import path from 'path';
+import { execSync, spawnSync } from 'child_process';
+
+let distDir: string | null = null;
+let cliPath: string | null = null;
+
+export function buildOnce() {
+  if (distDir && cliPath) return { distDir, cliPath };
+  distDir = fs.mkdtempSync(path.join(process.cwd(), 'dist-test-'));
+  const tsc = path.join(process.cwd(), 'node_modules', '.bin', 'tsc');
+  execSync(`${tsc} --outDir ${distDir}`, { stdio: 'inherit' });
+  cliPath = path.join(distDir, 'bin', 'dotenv-diff.js');
+  return { distDir, cliPath };
+}
+
+export function runCli(cwd: string, args: string[]) {
+  if (!cliPath) buildOnce();
+  return spawnSync('node', [cliPath!, ...args], { cwd, encoding: 'utf8' });
+}
+
+export function cleanupBuild() {
+  if (distDir) {
+    fs.rmSync(distDir, { recursive: true, force: true });
+    distDir = null;
+    cliPath = null;
+  }
+}

--- a/test/utils/fs-helpers.ts
+++ b/test/utils/fs-helpers.ts
@@ -1,0 +1,16 @@
+import fs from 'fs';
+import os from 'os';
+import path from 'path';
+
+export function makeTmpDir(prefix = 'dotenv-diff-') {
+  return fs.mkdtempSync(path.join(os.tmpdir(), prefix));
+}
+
+export function touch(filePath: string, content = '') {
+  fs.mkdirSync(path.dirname(filePath), { recursive: true });
+  fs.writeFileSync(filePath, content);
+}
+
+export function rmrf(p: string) {
+  fs.rmSync(p, { recursive: true, force: true });
+}

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -1,0 +1,8 @@
+import { defineConfig } from 'vitest/config';
+export default defineConfig({
+  test: {
+    include: ['test/**/*.test.ts'],
+    exclude: ['dist', 'node_modules'],
+    testTimeout: 15000,
+  },
+});


### PR DESCRIPTION
## Summary
- add shared fs/cli helpers and Vitest configuration
- restructure tests into unit, integration, and e2e suites
- verify CLI flags, autoscan, and git helpers across new test coverage

## Testing
- `npm test`
- `npm run test:unit`
- `npm run test:e2e`


------
https://chatgpt.com/codex/tasks/task_e_689b276d46ec8333a10f7efa81133317