### PR TITLE
Shortened config file path in CLI output to show only the filename.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ This project follows [Keep a Changelog](https://keepachangelog.com/) and [Semant
 
 - Updated dependencies to latest versions.
 - Moved `healthScore` further down on the console output for better visibility of issues.
+- Shortened config file path in CLI output to show only the filename.
 
 ### Fixed
 

--- a/src/ui/shared/printConfigStatus.ts
+++ b/src/ui/shared/printConfigStatus.ts
@@ -1,13 +1,16 @@
 import chalk from 'chalk';
+import path from 'path';
 
 /**
  * Prints message when dotenv-diff.config.json is successfully loaded.
- * @param path Path to the config file
+ * @param filePath The path to the loaded config file
  * @returns void
  */
-export function printConfigLoaded(path: string): void {
+export function printConfigLoaded(filePath: string): void {
+  const fileName = path.basename(filePath);
+
   console.log();
-  console.log(`${chalk.cyan('🧩 Loaded config:')} ${chalk.dim(path)}`);
+  console.log(`${chalk.cyan('🧩 Loaded config:')} ${chalk.dim(fileName)}`);
 }
 
 /**


### PR DESCRIPTION
<img width="316" height="36" alt="Skærmbillede 2025-12-17 kl  22 51 04" src="https://github.com/user-attachments/assets/db86d0db-779d-49af-bb9e-db4f9cec702b" />
