### PR TITLE
fix: default exclude keys where not ignored in scan mode

### DIFF
--- a/src/core/filterIgnoredKeys.ts
+++ b/src/core/filterIgnoredKeys.ts
@@ -3,6 +3,7 @@
  * But may be used in code. 
  */
 export const DEFAULT_EXCLUDE_KEYS = [
+  'PWD',
   'NODE_ENV',
   'VITE_MODE',
   'MODE',

--- a/src/core/scan/compareScan.ts
+++ b/src/core/scan/compareScan.ts
@@ -1,20 +1,26 @@
 import type { ScanResult } from '../../config/types.js';
+import { filterIgnoredKeys } from '../filterIgnoredKeys.js';
 
 /**
  * Compares the scan result with the environment variables.
  * This function identifies missing and unused environment variables.
  * @param scanResult - The result of the scan.
  * @param envVariables - The environment variables to compare against.
+ * @param ignore - List of keys to ignore.
+ * @param ignoreRegex - List of regex patterns to ignore.
  * @returns The comparison result.
  */
 export function compareWithEnvFiles(
   scanResult: ScanResult,
   envVariables: Record<string, string | undefined>,
+  ignore: string[] = [],
+  ignoreRegex: RegExp[] = [],
 ): ScanResult {
   const usedVariables = new Set(scanResult.used.map((u) => u.variable));
   const envKeys = new Set(Object.keys(envVariables));
 
-  const missing = [...usedVariables].filter((v) => !envKeys.has(v));
+  const missingUnfiltered = [...usedVariables].filter((v) => !envKeys.has(v));
+  const missing = filterIgnoredKeys(missingUnfiltered, ignore, ignoreRegex);
   const unused = [...envKeys].filter((v) => !usedVariables.has(v));
 
   return {

--- a/src/services/processComparisonFile.ts
+++ b/src/services/processComparisonFile.ts
@@ -91,7 +91,12 @@ export function processComparisonFile(
       opts.ignoreRegex,
     );
     envVariables = Object.fromEntries(envKeys.map((k) => [k, envFull[k]]));
-    scanResult = compareWithEnvFiles(scanResult, envVariables);
+    scanResult = compareWithEnvFiles(
+      scanResult,
+      envVariables,
+      opts.ignore,
+      opts.ignoreRegex,
+    );
     comparedAgainst = compareFile.name;
 
     // Detect uppercase keys

--- a/test/e2e/cli.flags.e2e.test.ts
+++ b/test/e2e/cli.flags.e2e.test.ts
@@ -429,6 +429,30 @@ describe('duplicate detection', () => {
     expect(envContent).not.toContain('IGNORED_VAR');
   });
 
+  it('Will ignore default excluded keys fx: MODE)', () => {
+    const cwd = tmpDir();
+    fs.writeFileSync(path.join(cwd, '.env'), 'EXISTING=value\n');
+    fs.writeFileSync(
+      path.join(cwd, 'app.js'),
+      `
+      const mode = process.env.MODE;
+      const pwd = process.env.PWD;
+      const newVar = process.env.NEW_VAR;
+    `,
+    );
+
+    const res = runCli(cwd, ['--scan-usage', '--fix']);
+    expect(res.status).toBe(0); // exit clean
+    expect(res.stdout).toContain('Auto-fix applied');
+    expect(res.stdout).toContain('Added 1 missing keys to .env');
+    expect(res.stdout).not.toContain('MODE');
+
+    const envContent = fs.readFileSync(path.join(cwd, '.env'), 'utf-8');
+    expect(envContent).toContain('NEW_VAR=');
+    expect(envContent).not.toContain('MODE=');
+    expect(envContent).not.toContain('PWD=');
+  });
+
   it('should exclude file when using --exclude-files', () => {
     const cwd = tmpDir();
     fs.writeFileSync(path.join(cwd, '.env'), 'EXISTING=value\n');

--- a/test/unit/core/filterIgnoredKeys.test.ts
+++ b/test/unit/core/filterIgnoredKeys.test.ts
@@ -26,6 +26,7 @@ describe('filterIgnoredKeys', () => {
 
   it('always filters out DEFAULT_EXCLUDE_KEYS', () => {
     const keys = [
+      'PWD',
       'API_KEY',
       'NODE_ENV',
       'MODE',
@@ -40,10 +41,13 @@ describe('filterIgnoredKeys', () => {
   });
 
   it('filters combination of ignore list, regex, and DEFAULT_EXCLUDE_KEYS', () => {
-    const keys = ['API_KEY', 'NODE_ENV', 'SECRET_TOKEN', 'MODE', 'DEBUG'];
+    const keys = ['API_KEY', 'NODE_ENV', 'SECRET_TOKEN', 'MODE', 'DEBUG', 'PWD'];
     const ignore = ['DEBUG'];
     const regex = [/^SECRET_/];
     const res = filterIgnoredKeys(keys, ignore, regex);
     expect(res).toEqual(['API_KEY']);
+    expect(res).not.toContain('NODE_ENV');
+    expect(res).not.toContain('MODE');
+    expect(res).not.toContain('PWD');
   });
 });


### PR DESCRIPTION
fix: default exclude keys where not ignored in scan mode

Fixes #195 
---

### Please don't delete this checklist! Before submitting the PR, please make sure you do the following:

- [x] Changes are small and focused
- [x] No breaking behavior or exit code changes
- [x] CLI output follows existing style
- [x] Link to related issues (if applicable)

### Tests

- [x] Tests pass (`pnpm run test`)
- [x] Ideally, include a test that fails without this PR but passes with it.

---

See [CONTRIBUTING.md](../CONTRIBUTING.md) for more details.
