### PR TITLE
fix: inconsistent naming warning ui

### DIFF
--- a/src/core/detectInconsistentNaming.ts
+++ b/src/core/detectInconsistentNaming.ts
@@ -27,8 +27,7 @@ export function detectInconsistentNaming(
 
       if (areInconsistentlyNamed(key1, key2)) {
         // Always suggest the snake_case version (the one with underscores)
-        const snakeCaseKey = key1.includes('_') ? key1 : key2;
-        const suggestion = `Consider using snake_case naming: '${snakeCaseKey}'`;
+        const suggestion = key1.includes('_') ? key1 : key2;
 
         warnings.push({
           key1,

--- a/src/ui/scan/printInconsistentNamingWarning.ts
+++ b/src/ui/scan/printInconsistentNamingWarning.ts
@@ -17,13 +17,15 @@ export function printInconsistentNamingWarning(
 
   console.log(chalk.yellow('⚠️  Inconsistent naming found:'));
 
-  for (const warning of warnings) {
+  for (const { key1, key2, suggestion } of warnings) {
     console.log(
       chalk.yellow(
-        `   You have both ${chalk.cyan(warning.key1)} and ${chalk.cyan(warning.key2)} (inconsistent naming)`,
+        `   - ${chalk.cyan(key1)} ↔ ${chalk.cyan(key2)}`,
       ),
     );
-    console.log(chalk.gray(`   ${warning.suggestion}`));
+    console.log(
+      chalk.gray(`     Suggested canonical name: ${suggestion}`),
+    );
   }
 
   console.log();

--- a/test/e2e/cli.inconsistentNaming.e2e.test.ts
+++ b/test/e2e/cli.inconsistentNaming.e2e.test.ts
@@ -55,7 +55,7 @@ describe('Inconsistent Naming Warnings', () => {
     expect(res.status).toBe(0);
     expect(res.stdout).toContain('Inconsistent naming found');
     expect(res.stdout).toContain(
-      'You have both API_KEY and APIKEY (inconsistent naming)',
+      'Suggested canonical name: API_KEY',
     );
   });
 
@@ -78,13 +78,13 @@ describe('Inconsistent Naming Warnings', () => {
     expect(res.status).toBe(0);
     expect(res.stdout).toContain('Inconsistent naming found');
     expect(res.stdout).toContain(
-      'You have both API_KEY and APIKEY (inconsistent naming)',
+      'Suggested canonical name: API_KEY',
     );
     expect(res.stdout).toContain(
-      'You have both DATABASE_URL and DATABASEURL (inconsistent naming)',
+      'Suggested canonical name: DATABASE_URL',
     );
     expect(res.stdout).toContain(
-      'You have both JWT_SECRET and JWTSECRET (inconsistent naming)',
+      'Suggested canonical name: JWT_SECRET',
     );
   });
 
@@ -127,7 +127,7 @@ describe('Inconsistent Naming Warnings', () => {
     expect(res.status).toBe(0);
     expect(res.stdout).toContain('Inconsistent naming found');
     expect(res.stdout).toContain(
-      'You have both API_KEY and api_key (inconsistent naming)',
+      'Suggested canonical name: API_KEY',
     );
   });
 
@@ -147,7 +147,7 @@ describe('Inconsistent Naming Warnings', () => {
     expect(res.status).toBe(1);
     expect(res.stdout).toContain('Inconsistent naming found');
     expect(res.stdout).toContain(
-      'You have both API_KEY and APIKEY (inconsistent naming)',
+      'Suggested canonical name: API_KEY',
     );
     expect(res.stdout).toContain('inconsistent naming patterns');
   });


### PR DESCRIPTION
Updated inconsistent naming warning ui

---

### Please don't delete this checklist! Before submitting the PR, please make sure you do the following:

- [x] Changes are small and focused
- [x] No breaking behavior or exit code changes
- [x] CLI output follows existing style
- [ ] Link to related issues (if applicable)

### Tests

- [x] Tests pass (`pnpm run test`)
- [ ] Ideally, include a test that fails without this PR but passes with it.

---

See [CONTRIBUTING.md](../CONTRIBUTING.md) for more details.
