### PR TITLE
fix: strip UTF-8 BOM in parseEnvContent to prevent corrupted first key

### DIFF
--- a/src/core/parseEnv.ts
+++ b/src/core/parseEnv.ts
@@ -8,7 +8,9 @@
  * Multi-line or quoted values are not supported.
  */
 export function parseEnvContent(content: string): Record<string, string> {
-  const lines = content.split('\n');
+  // Strip UTF-8 BOM if present to prevent corrupting the first key
+  const cleaned = content.startsWith('\uFEFF') ? content.slice(1) : content;
+  const lines = cleaned.split('\n');
 
   const result: Record<string, string> = {};
 

--- a/test/unit/core/parseEnv.test.ts
+++ b/test/unit/core/parseEnv.test.ts
@@ -216,4 +216,15 @@ ANOTHER=test`,
       CHINESE: '你好',
     });
   });
+
+  it('handles UTF-8 BOM without corrupting the first key', () => {
+    const envPath = path.join(dir, '.env');
+    fs.writeFileSync(envPath, '\uFEFFAPI_KEY=secret\nOTHER=value', 'utf-8');
+
+    const result = parseEnvFile(envPath);
+    expect(result).toEqual({
+      API_KEY: 'secret',
+      OTHER: 'value',
+    });
+  });
 });


### PR DESCRIPTION
## Bug
https://github.com/Chrilleweb/dotenv-diff/issues/305 — When a `.env` file starts with a UTF-8 BOM (`\uFEFF`), the BOM character is prepended to the first key, turning e.g. `API_KEY` into `\uFEFFAPI_KEY`. This causes false missing/extra differences in the diff output because the corrupted key never matches the expected one.

## Fix
Strip the BOM character at the start of `parseEnvContent` before splitting lines. The check is a single `startsWith` call — zero cost when no BOM is present.

## Testing
Added a test case in `parseEnv.test.ts` that writes a BOM-prefixed `.env` file and verifies the first key is parsed correctly without the `\uFEFF` prefix.

Happy to address any feedback.

Greetings, saschabuehrle