### PR TITLE
fix: env var usages being falsely dropped from scan

### DIFF
--- a/.changeset/skip-commented-usages-markers.md
+++ b/.changeset/skip-commented-usages-markers.md
@@ -1,0 +1,5 @@
+---
+'dotenv-diff': patch
+---
+
+fix env var usages being silently dropped from the scan when their line merely contained the substrings `<!--` or `-->`

--- a/packages/cli/src/core/scan/skipCommentedUsages.ts
+++ b/packages/cli/src/core/scan/skipCommentedUsages.ts
@@ -30,18 +30,29 @@ export function skipCommentedUsages(usages: readonly EnvUsage[]): EnvUsage[] {
       return false;
     }
 
-    if (line.includes('<!--')) insideHtmlComment = true;
-    if (line.includes('-->')) {
-      insideHtmlComment = false;
+    // Short-circuit before any HTML-comment bookkeeping: a stray `<!--`/`-->`
+    // on a line inside an ignore block must not leak into `insideHtmlComment`
+    // and drop live usages after the block ends.
+    if (insideIgnoreBlock) return false;
+
+    // HTML comment span tracking. Markers are only honoured at the *start* of
+    // the trimmed line — i.e. a genuine comment line — so `<!--`/`-->` embedded
+    // in code or string literals (e.g. `while (i --> 0)` or a `"<!--"` literal)
+    // never fake a comment and silently drop a real usage.
+    if (insideHtmlComment) {
+      // Somewhere inside a multi-line HTML comment: this usage is commented
+      // out. A `-->` anywhere on the line closes the comment.
+      if (line.includes('-->')) insideHtmlComment = false;
       return false;
     }
 
-    if (insideIgnoreBlock) return false;
+    if (line.startsWith('<!--')) {
+      // Opens an HTML comment. Unless it also closes on the same line, the
+      // comment continues onto the following usages.
+      if (!line.includes('-->')) insideHtmlComment = true;
+      return false;
+    }
 
-    return (
-      !insideHtmlComment &&
-      !/^\s*(\/\/|#|\/\*|\*|<!--|-->)/.test(line) &&
-      !hasIgnoreComment(line)
-    );
+    return !/^(\/\/|#|\/\*|\*|-->)/.test(line) && !hasIgnoreComment(line);
   });
 }

--- a/packages/cli/src/core/scan/skipCommentedUsages.ts
+++ b/packages/cli/src/core/scan/skipCommentedUsages.ts
@@ -2,6 +2,15 @@ import type { EnvUsage } from '../../config/types.js';
 import { hasIgnoreComment } from '../../core/security/secretDetectors.js';
 
 /**
+ * Matches an HTML comment terminator anywhere on a line. Per the WHATWG spec a
+ * comment closes with `-->` or the "abrupt closing" form `--!>`, so both count.
+ */
+const HTML_COMMENT_END = /--!?>/;
+
+/** Anchored comment-line prefixes: `//`, `#`, `/*`, `*`, or a closing `-->`/`--!>`. */
+const COMMENT_LINE_PREFIX = /^(\/\/|#|\/\*|\*|--!?>)/;
+
+/**
  * Filters out commented usages from the list.
  * Skipping comments:
  *   // process.env.API_URL
@@ -41,18 +50,18 @@ export function skipCommentedUsages(usages: readonly EnvUsage[]): EnvUsage[] {
     // never fake a comment and silently drop a real usage.
     if (insideHtmlComment) {
       // Somewhere inside a multi-line HTML comment: this usage is commented
-      // out. A `-->` anywhere on the line closes the comment.
-      if (line.includes('-->')) insideHtmlComment = false;
+      // out. A comment terminator anywhere on the line closes the comment.
+      if (HTML_COMMENT_END.test(line)) insideHtmlComment = false;
       return false;
     }
 
     if (line.startsWith('<!--')) {
       // Opens an HTML comment. Unless it also closes on the same line, the
       // comment continues onto the following usages.
-      if (!line.includes('-->')) insideHtmlComment = true;
+      if (!HTML_COMMENT_END.test(line)) insideHtmlComment = true;
       return false;
     }
 
-    return !/^(\/\/|#|\/\*|\*|-->)/.test(line) && !hasIgnoreComment(line);
+    return !COMMENT_LINE_PREFIX.test(line) && !hasIgnoreComment(line);
   });
 }

--- a/packages/cli/test/property/core/scan/skipCommentedUsages.property.test.ts
+++ b/packages/cli/test/property/core/scan/skipCommentedUsages.property.test.ts
@@ -1,0 +1,248 @@
+import { describe, test, expect } from 'vitest';
+import fc from 'fast-check';
+import { skipCommentedUsages } from '../../../../src/core/scan/skipCommentedUsages.js';
+import type { EnvUsage } from '../../../../src/config/types.js';
+
+/**
+ * Property-based ("fuzz") tests for the commented-usage filter.
+ *
+ * `skipCommentedUsages` is a small state machine: it walks the usages in order,
+ * toggling "inside HTML comment" and "inside ignore block" flags, and drops the
+ * ones that fall inside a comment. State that leaks between usages is exactly
+ * where such filters go wrong, so these tests hammer it with thousands of random
+ * usage sequences to prove the invariants that must hold under any reasonable
+ * semantics: it never throws, never invents or mutates a usage, keeps the output
+ * a faithful subsequence of the input, treats context-less usages as
+ * transparent, and is idempotent. Property-based testing is also what OpenSSF
+ * Scorecard recognises as fuzzing for JS/TS.
+ */
+
+const mkUsage = (variable: string, context?: string): EnvUsage =>
+  ({ variable, context }) as EnvUsage;
+
+/** A context string with no comment markers of any kind — always kept alone. */
+const plainContext = fc
+  .stringMatching(/^[A-Z][A-Z0-9_]{0,10}$/)
+  .map((v) => `const x = process.env.${v}`);
+
+/** Leading single-line comment prefixes the filter recognises. */
+const commentPrefix = fc.constantFrom('//', '#', '/*', ' *', '   //', '  # ');
+
+/** Arbitrary usage whose context may be anything, including undefined/binary. */
+const arbitraryUsage = fc
+  .record({
+    variable: fc.string(),
+    context: fc.option(fc.string({ unit: 'binary' }), { nil: undefined }),
+  })
+  .map(({ variable, context }) => mkUsage(variable, context));
+
+/** Compares two arrays by reference identity, element for element. */
+const sameRefs = (a: readonly EnvUsage[], b: readonly EnvUsage[]) => {
+  expect(a.length).toBe(b.length);
+  for (let i = 0; i < a.length; i++) expect(a[i]).toBe(b[i]);
+};
+
+describe('skipCommentedUsages (property-based)', () => {
+  test('never throws on arbitrary usage sequences', () => {
+    fc.assert(
+      fc.property(fc.array(arbitraryUsage, { maxLength: 40 }), (usages) => {
+        skipCommentedUsages(usages);
+      }),
+      { numRuns: 3000 },
+    );
+  });
+
+  test('never throws (and stays fast) on adversarial marker runs', () => {
+    // Long runs of the whitespace/dash characters the ignore-block regexes
+    // repeat, guarding against catastrophic backtracking (ReDoS).
+    const nasty = fc
+      .tuple(
+        fc.constantFrom('<!--', '-->', '<!-- dotenv', '', 'x'),
+        fc.integer({ min: 0, max: 4000 }),
+        fc.constantFrom(' ', '-', '\t', ' -'),
+      )
+      .map(([head, n, fill]) => mkUsage('V', head + fill.repeat(n)));
+    fc.assert(
+      fc.property(fc.array(nasty, { maxLength: 10 }), (usages) => {
+        skipCommentedUsages(usages);
+      }),
+      { numRuns: 200 },
+    );
+  });
+
+  test('output is a reference-preserving subsequence of the input', () => {
+    fc.assert(
+      fc.property(fc.array(arbitraryUsage, { maxLength: 40 }), (usages) => {
+        const out = skipCommentedUsages(usages);
+        // Never longer, never invents elements, order preserved, no mutation.
+        expect(out.length).toBeLessThanOrEqual(usages.length);
+        let searchFrom = 0;
+        for (const item of out) {
+          const idx = usages.indexOf(item, searchFrom);
+          expect(idx).toBeGreaterThanOrEqual(searchFrom);
+          searchFrom = idx + 1;
+        }
+      }),
+      { numRuns: 3000 },
+    );
+  });
+
+  test('usages without a context are always kept', () => {
+    const blank = fc.oneof(
+      fc.constant(mkUsage('V', undefined)),
+      fc.constant(mkUsage('V', '')),
+    );
+    fc.assert(
+      fc.property(
+        fc.array(fc.oneof(arbitraryUsage, blank), { maxLength: 40 }),
+        (usages) => {
+          const out = skipCommentedUsages(usages);
+          for (const u of usages) {
+            if (!u.context) expect(out).toContain(u);
+          }
+        },
+      ),
+      { numRuns: 2000 },
+    );
+  });
+
+  test('context-less usages are transparent to the state machine', () => {
+    // Sprinkling in usages with no context must not change the fate of the
+    // others — dropping the blanks first yields the same with-context result.
+    const blank = fc.constant(mkUsage('BLANK', undefined));
+    fc.assert(
+      fc.property(
+        fc.array(fc.oneof(arbitraryUsage, blank), { maxLength: 40 }),
+        (usages) => {
+          const withBlanks = skipCommentedUsages(usages).filter(
+            (u) => u.context,
+          );
+          const withoutBlanks = skipCommentedUsages(
+            usages.filter((u) => u.context),
+          );
+          sameRefs(withBlanks, withoutBlanks);
+        },
+      ),
+      { numRuns: 2000 },
+    );
+  });
+
+  test('is idempotent — filtering the result changes nothing', () => {
+    fc.assert(
+      fc.property(fc.array(arbitraryUsage, { maxLength: 40 }), (usages) => {
+        const once = skipCommentedUsages(usages);
+        const twice = skipCommentedUsages(once);
+        sameRefs(twice, once);
+      }),
+      { numRuns: 3000 },
+    );
+  });
+
+  test('a lone plain usage is always kept', () => {
+    fc.assert(
+      fc.property(plainContext, (ctx) => {
+        const u = mkUsage('V', ctx);
+        expect(skipCommentedUsages([u])).toEqual([u]);
+      }),
+      { numRuns: 1000 },
+    );
+  });
+
+  test('a lone comment-prefixed usage is always dropped', () => {
+    fc.assert(
+      fc.property(commentPrefix, plainContext, (prefix, ctx) => {
+        expect(skipCommentedUsages([mkUsage('V', `${prefix} ${ctx}`)])).toEqual(
+          [],
+        );
+      }),
+      { numRuns: 1000 },
+    );
+  });
+
+  test('a lone inline `dotenv-diff-ignore` usage is always dropped', () => {
+    fc.assert(
+      fc.property(plainContext, (ctx) => {
+        expect(
+          skipCommentedUsages([mkUsage('V', `${ctx} // dotenv-diff-ignore`)]),
+        ).toEqual([]);
+      }),
+      { numRuns: 1000 },
+    );
+  });
+
+  test('a marker embedded mid-line in real code never drops the usage', () => {
+    // Regression guard: `<!--`/`-->` only count at the start of a trimmed line.
+    // Mid-line occurrences (string literals, the `i --> 0` idiom) are code.
+    const embedded = fc.oneof(
+      plainContext.map((c) => `${c} // uses <!-- in a string`),
+      plainContext.map((c) => `while (i --> 0) { ${c} }`),
+      plainContext.map((c) => `const s = "<!-- literal"; ${c}`),
+    );
+    fc.assert(
+      fc.property(embedded, (ctx) => {
+        const u = mkUsage('V', ctx);
+        expect(skipCommentedUsages([u])).toEqual([u]);
+      }),
+      { numRuns: 1000 },
+    );
+  });
+
+  test('an ignore block never leaks HTML-comment state onto usages after it', () => {
+    // Regression guard (state leak): a stray `<!--`/`-->` on a line inside the
+    // ignore block must not drop plain usages that follow the block.
+    const strayInside = fc.constantFrom(
+      'process.env.MID <!-- stray open',
+      'foo(process.env.MID) -->',
+      'x = "<!--" + process.env.MID',
+    );
+    fc.assert(
+      fc.property(
+        fc.array(strayInside, { maxLength: 4 }),
+        plainContext,
+        (inner, afterCtx) => {
+          const after = mkUsage('AFTER', afterCtx);
+          const usages = [
+            mkUsage('START', '<!-- dotenv-diff-ignore-start -->'),
+            ...inner.map((c, i) => mkUsage(`I${i}`, c)),
+            mkUsage('END', '<!-- dotenv-diff-ignore-end -->'),
+            after,
+          ];
+          expect(skipCommentedUsages(usages)).toEqual([after]);
+        },
+      ),
+      { numRuns: 1000 },
+    );
+  });
+
+  test('everything between well-formed ignore markers is dropped, plain code around it is kept', () => {
+    // Inner lines may even carry stray HTML markers — the ignore block must
+    // still fully contain them without leaking state onto the surrounding code.
+    const cleanInner = fc.oneof(
+      plainContext,
+      fc.tuple(commentPrefix, plainContext).map(([p, c]) => `${p} ${c}`),
+      fc.constant('process.env.INNER <!-- stray'),
+      fc.constant('process.env.INNER -->'),
+    );
+    fc.assert(
+      fc.property(
+        fc.array(plainContext, { maxLength: 4 }),
+        fc.array(cleanInner, { maxLength: 4 }),
+        fc.array(plainContext, { maxLength: 4 }),
+        (before, inner, after) => {
+          const beforeU = before.map((c, i) => mkUsage(`B${i}`, c));
+          const afterU = after.map((c, i) => mkUsage(`A${i}`, c));
+          const usages = [
+            ...beforeU,
+            mkUsage('START', '<!-- dotenv-diff-ignore-start -->'),
+            ...inner.map((c, i) => mkUsage(`I${i}`, c)),
+            mkUsage('END', '<!-- dotenv-diff-ignore-end -->'),
+            ...afterU,
+          ];
+          const out = skipCommentedUsages(usages);
+          sameRefs(out, [...beforeU, ...afterU]);
+        },
+      ),
+      { numRuns: 1000 },
+    );
+  });
+});

--- a/packages/cli/test/unit/core/scan/skipCommentedUsages.test.ts
+++ b/packages/cli/test/unit/core/scan/skipCommentedUsages.test.ts
@@ -175,4 +175,38 @@ describe('skipCommentedUsages', () => {
   it('handles empty array', () => {
     expect(skipCommentedUsages([])).toEqual([]);
   });
+
+  // ---- regressions: markers embedded in code/strings must not drop usages ----
+
+  it('keeps a usage after an ignore block even if a line inside it had a stray <!--', () => {
+    // Regression (case A): the stray `<!--` used to set insideHtmlComment, which
+    // ignore-end never reset, silently dropping AFTER.
+    const usages = [
+      usage('START', '<!-- dotenv-diff-ignore-start -->'),
+      usage('MID', 'process.env.MID <!-- stray open'),
+      usage('END', '<!-- dotenv-diff-ignore-end -->'),
+      usage('AFTER', 'process.env.AFTER'),
+    ];
+    expect(skipCommentedUsages(usages).map((u) => u.variable)).toEqual([
+      'AFTER',
+    ]);
+  });
+
+  it('keeps a usage on a line containing --> in real code', () => {
+    // Regression (case B): `-->` is the "goes to" idiom here, not a comment close.
+    const usages = [usage('X', 'while (i --> 0) { use(process.env.X) }')];
+    expect(skipCommentedUsages(usages).map((u) => u.variable)).toEqual(['X']);
+  });
+
+  it('does not let a mid-line <!-- inside a string poison following usages', () => {
+    // Regression (case C): `<!--` inside a string literal is not a comment.
+    const usages = [
+      usage('P', 'const s = "<!-- not a comment" + process.env.P'),
+      usage('Q', 'process.env.Q'),
+    ];
+    expect(skipCommentedUsages(usages).map((u) => u.variable)).toEqual([
+      'P',
+      'Q',
+    ]);
+  });
 });

--- a/packages/cli/test/unit/core/scan/skipCommentedUsages.test.ts
+++ b/packages/cli/test/unit/core/scan/skipCommentedUsages.test.ts
@@ -198,6 +198,20 @@ describe('skipCommentedUsages', () => {
     expect(skipCommentedUsages(usages).map((u) => u.variable)).toEqual(['X']);
   });
 
+  it('treats the abrupt-close form --!> as a comment terminator', () => {
+    // Per the WHATWG spec `--!>` also closes an HTML comment, so the usage on
+    // the following line must be kept (the comment ends, it is not inside it).
+    const usages = [
+      usage('OPEN', '<!-- commented out'),
+      usage('INSIDE', 'process.env.INSIDE'),
+      usage('CLOSE', '--!>'),
+      usage('AFTER', 'process.env.AFTER'),
+    ];
+    expect(skipCommentedUsages(usages).map((u) => u.variable)).toEqual([
+      'AFTER',
+    ]);
+  });
+
   it('does not let a mid-line <!-- inside a string poison following usages', () => {
     // Regression (case C): `<!--` inside a string literal is not a comment.
     const usages = [


### PR DESCRIPTION
<!-- Your PR description here -->

---

### Please don't delete this checklist! Before submitting the PR, please make sure you do the following:

- [x] Changes are small, focused, and easy to review
- [ ] Link to related issues (if applicable)
- [x] The existing code style and project structure are followed

### Tests

- [x] Relevant tests have been added or updated

### Documentation

- [ ] Documentation has been updated if necessary (e.g., README, docs folder)

---

See [CONTRIBUTING.md](https://github.com/Chrilleweb/dotenv-diff/blob/main/CONTRIBUTING.md)
